### PR TITLE
Make sure we don't kill ourselves if pgrep matches

### DIFF
--- a/run-one
+++ b/run-one
@@ -71,7 +71,10 @@ case "$base" in
 		# Loop through matching pids
 		for p in $(pgrep -u "$USER" -f "^$ps$" || true); do
 			# Try to kill pid
-			kill $p
+			if [ "$p" = "$$" ] ; then
+				continue
+			fi
+			ps $p >/dev/null && kill $p
 			# And then block until killed
 			while ps $p >/dev/null 2>&1; do
 				kill $p


### PR DESCRIPTION
pgrep could get confused when the command contains regular xpressions that match the run-* command itself, e.g. an argument like `foo 'a|b'`

```
$ cat /tmp/sleepforever
#!/bin/bash
echo Sleeping for 99 days...
sleep +99d



# version in HEAD
$ run-this-one /tmp/sleepforever
Sleeping for 99 days...
<ctrl-c>

$ run-this-one /tmp/sleepforever  "a|b"
Terminated
```

Run with `-x` you find the problem is this:

```
+ base=run-this-one
+ ps=/tmp/sleepforever a|b
+ pgrep -u wbagg -f ^/tmp/sleepforever a|b$
+ kill 768759
Terminated
```

pgrep is matching our `run-this-one` command and itself. The `$$` check verifies that we don't kill run-this-one, the `ps` addition assures we don't kill the (no longer running) `pgrep`.


